### PR TITLE
get it to build for linux/mac/switch/wii u and add tts logging

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -167,6 +167,11 @@ else()
     list(FILTER soh__Enhancements EXCLUDE REGEX "soh/Enhancements/speechsynthesizer/(Darwin|SAPI).*")
 endif()
 
+# handle accessible audio engine removals
+if (CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
+    list(FILTER soh__Enhancements EXCLUDE REGEX "soh/Enhancements/accessible-actors/*")
+endif()
+
 source_group("soh\\Enhancements" REGULAR_EXPRESSION "soh/Enhancements/*")
 source_group("soh\\Enhancements\\audio" REGULAR_EXPRESSION "soh/Enhancements/audio/*")
 source_group("soh\\Enhancements\\controls" REGULAR_EXPRESSION "soh/Enhancements/controls/*")

--- a/soh/soh/Enhancements/accessible-actors/AccessibleActorList.cpp
+++ b/soh/soh/Enhancements/accessible-actors/AccessibleActorList.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string>
 #include <float.h>
-#include "overlays\actors\ovl_Boss_Goma\z_boss_goma.h"
+#include "overlays/actors/ovl_Boss_Goma/z_boss_goma.h"
 //Declarations specific to chests.
 #include "overlays/actors/ovl_En_Box/z_en_box.h"
 extern "C" {
@@ -22,7 +22,7 @@ extern "C" {
 void EnKarebaba_DeadItemDrop(EnKarebaba*, PlayState*);
 }
 //Declarations specific to Torches
-#include "overlays\actors\ovl_Obj_Syokudai\z_obj_syokudai.h"
+#include "overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h"
 //User data for the general helper VA.
 typedef struct
 {

--- a/soh/soh/Enhancements/accessible-actors/AccessibleAudioEngine.h
+++ b/soh/soh/Enhancements/accessible-actors/AccessibleAudioEngine.h
@@ -5,6 +5,7 @@
 #include <thread>
 #include <mutex>
 #include <deque>
+#include <condition_variable>
 #include <string>
 #include <unordered_map>
 #include <array>

--- a/soh/soh/Enhancements/accessible-actors/SfxExtractor.cpp
+++ b/soh/soh/Enhancements/accessible-actors/SfxExtractor.cpp
@@ -7,6 +7,7 @@
 #include "functions.h"
 #include "soh/OTRGlobals.h"
 #include "SfxTable.h"
+#include <sstream>
 const char* GetLanguageCode();
 extern "C" {
 extern Vec3f D_801333D4;

--- a/soh/soh/Enhancements/accessible-actors/accessibility_cues.cpp
+++ b/soh/soh/Enhancements/accessible-actors/accessibility_cues.cpp
@@ -2,6 +2,7 @@
 #include "z64.h"
 #include "macros.h"
 #include "functions.h"
+#include <cmath>
 extern "C" {
 s32 func_80839768(PlayState* play, Player* p, Vec3f* arg2, CollisionPoly** arg3, s32* arg4, Vec3f* arg5);
 void func_8083E298(CollisionPoly* arg0, Vec3f* arg1, s16* arg2);

--- a/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.cpp
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.cpp
@@ -1,0 +1,16 @@
+#include "SpeechLogger.h"
+#include <libultraship/libultraship.h>
+
+SpeechLogger::SpeechLogger() {
+}
+
+void SpeechLogger::Speak(const char* text, const char* language) {
+    lusprintf(__FILE__, __LINE__, 2, "Spoken Text (%s): %s", language, text);
+}
+
+bool SpeechLogger::DoInit() {
+    return true;
+}
+
+void SpeechLogger::DoUninitialize() {
+}

--- a/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.h
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.h
@@ -1,0 +1,17 @@
+#ifndef SOHSpeechLogger_h
+#define SOHSpeechLogger_h
+
+#include "SpeechSynthesizer.h"
+
+class SpeechLogger : public SpeechSynthesizer {
+  public:
+    SpeechLogger();
+
+    void Speak(const char* text, const char* language);
+
+  protected:
+    bool DoInit(void);
+    void DoUninitialize(void);
+};
+
+#endif

--- a/soh/soh/Enhancements/speechsynthesizer/SpeechSynthesizer.h
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechSynthesizer.h
@@ -36,3 +36,5 @@ class SpeechSynthesizer {
 #elif defined(__APPLE__)
 #include "DarwinSpeechSynthesizer.h"
 #endif
+
+#include "SpeechLogger.h"

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -114,8 +114,9 @@ CrowdControl* CrowdControl::Instance;
 #include "soh/resource/importer/BackgroundFactory.h"
 
 #include "soh/config/ConfigUpdaters.h"
-#include "soh/Enhancements/accessible-actors/ActorAccessibility.h"
-#include "Enhancements//accessible-actors/ActorAccessibility.h"
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+#include "Enhancements/accessible-actors/ActorAccessibility.h"
+#endif
 OTRGlobals* OTRGlobals::Instance;
 SaveManager* SaveManager::Instance;
 CustomMessageManager* CustomMessageManager::Instance;
@@ -467,10 +468,11 @@ void OTRAudio_Thread() {
         for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
             AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS),
                                            num_audio_samples);
+#if !defined(__SWITCH__) && !defined(__WIIU__)
             // Give accessibility a chance to merge its own audio in.
             ActorAccessibility_MixAccessibleAudioWithGameAudio(
                 audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS), num_audio_samples);
-
+#endif
         }
         AudioPlayer_Play((u8*)audio_buffer, num_audio_samples * (sizeof(int16_t) * NUM_AUDIO_CHANNELS * AUDIO_FRAMES_PER_UPDATE));
 
@@ -1049,7 +1051,9 @@ extern "C" void InitOTR() {
     
     clearMtx = (uintptr_t)&gMtxClear;
     OTRMessage_Init();
+    #if !defined(__SWITCH__) && !defined(__WIIU__)
     ActorAccessibility_Init();
+    #endif
     OTRAudio_Init();
     OTRExtScanner();
     VanillaItemTable_Init();
@@ -1094,7 +1098,9 @@ extern "C" void DeinitOTR() {
     CrowdControl::Instance->Disable();
     CrowdControl::Instance->Shutdown();
 #endif
+#if !defined(__SWITCH__) && !defined(__WIIU__)
     ActorAccessibility_Shutdown();
+#endif
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before these shared ptrs.
     SohGui::Destroy();
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2541,7 +2541,9 @@ void OTRAudio_SfxCaptureThread() {
             }
         }
         std::unique_lock<std::mutex> Lock(audio.mutex);
+#if !defined(__SWITCH__) && !defined(__WIIU__)
         ActorAccessibility_DoSoundExtractionStep();
+#endif
         audio.processing = false;
         audio.cv_from_thread.notify_one();
     }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1042,6 +1042,9 @@ extern "C" void InitOTR() {
 #elif defined(_WIN32)
     SpeechSynthesizer::Instance = new SAPISpeechSynthesizer();
     SpeechSynthesizer::Instance->Init();
+#else
+    SpeechSynthesizer::Instance = new SpeechLogger();
+    SpeechSynthesizer::Instance->Init();
 #endif
     
     clearMtx = (uintptr_t)&gMtxClear;


### PR DESCRIPTION
this gets it building on the rest of the platforms

i was hoping to not need to ifdef out all the stuff for switch and wii u (using `MA_NO_RUNTIME_LINKING` got it so switch builds but wii u still fails)

wii u error from that attempt
```
/opt/devkitpro/devkitPPC/bin/../lib/gcc/powerpc-eabi/13.2.0/../../../../powerpc-eabi/bin/ld: soh/CMakeFiles/soh.dir/soh/Enhancements/accessible-actors/AccessibleAudioEngine.o: in function `ma_job_queue_post':
/home/briaguya/code/Shipwright/soh/soh/Enhancements/accessible-actors/miniaudio.h:17637:(.text.ma_job_queue_post+0xf4): undefined reference to `__atomic_load_8'
```

so basically miniaudio may be a no-go on wii u (unless someone wants to dig into getting it working)

either way this PR should get the branch building across the board